### PR TITLE
move ask_q() off to util.py, make CLI() use it for nuking confirmation

### DIFF
--- a/cloudvirt/cli.py
+++ b/cloudvirt/cli.py
@@ -5,6 +5,7 @@ from .config import ConfigYAML
 from .driver import APIDriver
 from .log import set_root_logger
 from .mkuser import MkUser
+from .util import ask_q
 
 from . import __version__ as pkg_version
 
@@ -91,8 +92,11 @@ class CLI:
             want_nuke = True
         else:
             while True:
-                self.logger.info("do you want %s nuked? (y/n): ", self.args.name)
-                consent = str(input().lower().strip(" "))
+                consent = (
+                    ask_q(f"do you want {self.args.name} nuked? (y/n)")
+                    .lower()
+                    .strip(" ")
+                )
 
                 want_nuke = (
                     True if consent == "y" else False if consent == "n" else None

--- a/cloudvirt/mkuser.py
+++ b/cloudvirt/mkuser.py
@@ -1,10 +1,10 @@
-import getpass
-import logging
 import time
 
 import yaml
 
 from passlib.hash import sha512_crypt
+
+from .util import ask_q
 
 
 class MkUser:
@@ -14,29 +14,9 @@ class MkUser:
         self.userspec_yaml_dict = {"userspec": []}
         self.user_names = []
 
-    def _ask_q(self, query, passwd=False):
-        # momentarily replace the streamhandler terminator so that we get rid
-        # of the ugly newlines when expecting user input
-        logging.StreamHandler.terminator = ""
-        self.logger.info("%s: ", query)
-
-        try:
-            if passwd:
-                response = getpass.getpass(prompt="", stream=None)
-            else:
-                response = str(input())
-        except (EOFError, KeyboardInterrupt):
-            print()
-            logging.StreamHandler.terminator = "\n"
-            self.logger.error("user cancelled the action, exiting")
-
-        logging.StreamHandler.terminator = "\n"
-
-        return response
-
     def _get_name(self):
         while True:
-            name = self._ask_q("input user name")
+            name = ask_q("input user name")
 
             if not name:
                 self.logger.warning("user name cannot be empty, retry")
@@ -57,8 +37,8 @@ class MkUser:
 
     def _get_passwd(self):
         while True:
-            pass1 = self._ask_q("input user password", passwd=True)
-            pass2 = self._ask_q("repeat user password", passwd=True)
+            pass1 = ask_q("input user password", passwd=True)
+            pass2 = ask_q("repeat user password", passwd=True)
 
             if pass1 == pass2:
                 if not pass1:
@@ -79,15 +59,13 @@ class MkUser:
         ssh_keys, ssh_done = [], False
 
         while ssh_done is False:
-            want_ssh = (
-                self._ask_q("do you want to add ssh keys? (y/n)").lower().strip(" ")
-            )
+            want_ssh = ask_q("do you want to add ssh keys? (y/n)").lower().strip(" ")
 
             if want_ssh == "y":
                 self.logger.info("input ssh keys, provide an empty line when done")
 
                 while True:
-                    ask_ssh = self._ask_q("input ssh key")
+                    ask_ssh = ask_q("input ssh key")
 
                     if not ask_ssh:
                         if not ssh_keys:
@@ -122,7 +100,7 @@ class MkUser:
 
     def _get_sudo_god_mode(self):
         while True:
-            consent = self._ask_q("do you want sudo god mode? (y/n)").lower().strip(" ")
+            consent = ask_q("do you want sudo god mode? (y/n)").lower().strip(" ")
 
             sudo_god_mode = (
                 True if consent == "y" else False if consent == "n" else None
@@ -159,7 +137,7 @@ class MkUser:
 
             # round 2 and onward
             while True:
-                want_more_users = self._ask_q("add more users? (y/n)").lower().strip()
+                want_more_users = ask_q("add more users? (y/n)").lower().strip()
                 if want_more_users == "y":
                     break
 

--- a/cloudvirt/util.py
+++ b/cloudvirt/util.py
@@ -1,0 +1,30 @@
+import getpass
+import inspect
+import logging
+
+
+def ask_q(query, passwd=False):
+    # get the logger of the class that's calling this function
+    class_name = inspect.stack()[2].frame.f_locals["self"].__class__.__name__
+    class_name = "cloudvirt" if class_name == "CLI" else f"cloudvirt.{class_name}"
+
+    logger = logging.getLogger(class_name)
+
+    # momentarily replace the streamhandler terminator so that we get rid
+    # of the ugly newlines when expecting user input
+    logging.StreamHandler.terminator = ""
+    logger.info("%s: ", query)
+
+    try:
+        if passwd:
+            response = getpass.getpass(prompt="", stream=None)
+        else:
+            response = str(input())
+    except (EOFError, KeyboardInterrupt):
+        print()
+        logging.StreamHandler.terminator = "\n"
+        logger.error("user cancelled the action, exiting")
+
+    logging.StreamHandler.terminator = "\n"
+
+    return response


### PR DESCRIPTION
the `getLogger` from the stack works only for children of CLI() but we do not care for more complex logic as the only places the user input is queried is covered with this depth.